### PR TITLE
Improve Error Reporting During Setup

### DIFF
--- a/CAT_MH_CHA.php
+++ b/CAT_MH_CHA.php
@@ -399,6 +399,11 @@ class CAT_MH_CHA extends \ExternalModules\AbstractExternalModule {
 		$interview = $this->createInterview($args);
 		$interview['subjectID'] = $valid_sid;
 		
+		if(array_key_exists("moduleError", $interview) && $interview['moduleError']) {
+			echo("CAT-MH encountered an error with the API:<br />" . $interview['moduleMessage']);
+			return false;
+		}
+		
 		$new_interview = [
 			"sequence" => $sequence,
 			"scheduled_datetime" => $sched_dt,

--- a/resultsReport.php
+++ b/resultsReport.php
@@ -111,7 +111,7 @@ require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';
 					<tr>
 						<td><?=htmlspecialchars($rid, ENT_QUOTES)?></td>
 						<td><?=htmlspecialchars($sequence_datetime, ENT_QUOTES)?></td>
-						<td>" . date("Y-m-d H:i", $interview->timestamp) . "</td>
+						<td><?=date("Y-m-d H:i", $interview->timestamp)?></td>
 						<td><?=htmlspecialchars($sequence_name, ENT_QUOTES)?></td>
 						<td><?=htmlspecialchars($test_name, ENT_QUOTES)?></td>
 						<td><?=htmlspecialchars($test->diagnosis, ENT_QUOTES)?></td>
@@ -121,8 +121,8 @@ require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';
 						<td><?=htmlspecialchars($test->precision, ENT_QUOTES)?></td>
 						<td><?=htmlspecialchars($test->prob, ENT_QUOTES)?></td>
 						<td><?=htmlspecialchars($test->percentile, ENT_QUOTES)?></td>
-						<td>$phq9</td>
-						<td>$reviewed_cbox</td>
+						<td><?=$phq9?></td>
+						<td><?=$reviewed_cbox?></td>
 					</tr>
                     <?php
 				}


### PR DESCRIPTION
There existed some functionality to report errors, but those aren't seen by the makeInterview function. UC Denver reported an issue with setup that this might help resolve.