### PR TITLE
Remove unneeded "value" key from getProjectSettings array

### DIFF
--- a/CAT_MH_CHA.php
+++ b/CAT_MH_CHA.php
@@ -403,7 +403,7 @@ class CAT_MH_CHA extends \ExternalModules\AbstractExternalModule {
 						$args['tests'][] = ["type" => $this->convertTestAbbreviation[$testAbbreviation]];
 					}
 				}
-				$args['language'] = $projectSettings['language']['value'][$i] == 2 ? 2 : 1;
+				$args['language'] = $projectSettings['language'][$i] == 2 ? 2 : 1;
 			}
 		}
 		
@@ -1740,16 +1740,16 @@ class CAT_MH_CHA extends \ExternalModules\AbstractExternalModule {
 		$projectSettings = $this->getProjectSettings();
 		
 		## Module not configured
-		if(!isset($projectSettings['sequence']['value'])) {
+		if(!isset($projectSettings['sequence'])) {
 			$out['moduleError'] = true;
 			$out['moduleMessage'] = "Module not configured with a sequence";
 			return $out;
 		}
 		
-		foreach ($projectSettings['sequence']['value'] as $j => $seqName) {
+		foreach ($projectSettings['sequence'] as $j => $seqName) {
 			if ($sequence == $seqName) {
 				foreach($testTypes as $testType) {
-					if ($projectSettings[$testType . '_show_results']['value'][$j] == 1) {
+					if ($projectSettings[$testType . '_show_results'][$j] == 1) {
 						$keepResults[$testType] = true;
 					}
 				}


### PR DESCRIPTION
Prevents erroneous appearance of "Module not configured with a sequence" error after completion of a survey.

Root cause of this error was that modules with framework 5+ do not nest project settings under a `value` key, even if `getProjectSettings` is not called from the framework: https://github.com/vanderbilt-redcap/external-module-framework-docs/blob/main/versions/v5.md

This bug is nearly 4 years old! It was introduced in this commit: a685e22da66cb978289ffc9313c3852fabd9cc6c

---

I wrote this bit of javascript to make answering the CAT_MH survey questions a bit less annoying:

```js
N_QUESTIONS = 20;
async function answerQ(q_load_ms = 2500) {
    b = $(".answerSelector[data-ordinal='1']");
    b.trigger("mousedown");
    b.addClass("selected");

    await new Promise(r => setTimeout(r, 100));

    a = $("#submitAnswer");
    a.trigger("mousedown");

    await new Promise(r => setTimeout(r, q_load_ms));
}

for (let i = 0; i < N_QUESTIONS; i++) {
    answerQ();
}
```