### PR TITLE
recursively apply htmlspecialchars to interview response data when exporting

### DIFF
--- a/php/export_interviews.php
+++ b/php/export_interviews.php
@@ -1,10 +1,19 @@
 <?php
+namespace VICTR\REDCAP\CAT_MH_CHA;
+
 $months = intval($_GET['months']);
 if ($months < 0)
 	$months = 0;
 
 $interviews = [];
 $result = $module->queryLogs("SELECT interview WHERE message = ?", ['catmh_interview']);
+
+function recursive_htmlspecialchars($value) {
+	return (is_array($value)) ?
+		array_map('VICTR\REDCAP\CAT_MH_CHA\recursive_htmlspecialchars', $value) :
+		htmlspecialchars($value, ENT_QUOTES);
+}
+
 while ($row = db_fetch_assoc($result)) {
 	$interview = json_decode($row['interview'], true);
 	unset($interview["jsessionid"]);
@@ -12,7 +21,8 @@ while ($row = db_fetch_assoc($result)) {
 	if (strtotime($interview["scheduled_datetime"] . " + $months months") < time()) {
 		$outputInterview = [];
 		foreach($interview as $index => $value) {
-			$outputInterview[htmlspecialchars($index, ENT_QUOTES)] = htmlspecialchars($value, ENT_QUOTES);
+			$sanitized_value = recursive_htmlspecialchars($value);
+			$outputInterview[htmlspecialchars($index, ENT_QUOTES)] = $sanitized_value;
 		}
 		$interviews[] = $outputInterview;
 	}


### PR DESCRIPTION
Prevents an error when using the "Export Selected Interview Data" on the page "CAT-MH Export and Delete Interviews" caused by some values (`types`, `labels`, and `results`) being multidimensional.