### PR TITLE
Flush cachedInterviews array between projects during email cron

### DIFF
--- a/CAT_MH_CHA.php
+++ b/CAT_MH_CHA.php
@@ -189,7 +189,9 @@ class CAT_MH_CHA extends \ExternalModules\AbstractExternalModule {
 		$originalPid = htmlentities($_GET['pid'], ENT_QUOTES, 'UTF-8');
 		foreach($this->framework->getProjectsWithModuleEnabled() as $localProjectId) {
 			$_GET['pid'] = $localProjectId;
-			
+
+			// avoid cross-project contamination
+			$this->cachedInterviews = [];
 			$this->sendInvitations(time());
 			
 			$today_ymd = date("Y-m-d");
@@ -863,7 +865,7 @@ class CAT_MH_CHA extends \ExternalModules\AbstractExternalModule {
 		}
 		
 		if(array_key_exists("pid", $_GET)) {
-			$this->cachedSequences = $sequences;
+			$this->cachedSequences[$_GET["pid"]] = $sequences;
 		}
 		
 		return $sequences;


### PR DESCRIPTION
# Pre-flight Checklist
- [x] Are all the features in this PR tested? 
- [x] Have other features this PR touches also been tested?
- [x] Has the code been formatted for consistency and readability?


# Overview
<!--Provide a summary  of this pr. Is this a new module? A new feature? a bug fix? a code reformat?-->

Prevents erroneous reminders being sent to interviewees in cases where the same sequence name appears in multiple projects applied to the same `record_id`  
Credit to Ryan Moore for discovering this!

Also fixes cachedSequences issue where project_id was expected as a key but array was actually 1 dimensional  
May have eventually caused data loss/mismatch, but none expected as would require there be enough sequences to reach a valid project_id

