### PR TITLE
Add cron to copy interview data to a field specified in project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The following field is optional, but required to use the automatic provider emai
 You can configure any number of CAT-MH sequences. Each sequence consists of a series of CAT-MH tests that make up a CAT-MH interview.
 
 To do so, go to the "External Modules" page and click "Configure" for the CAT-MH module. You can select any number of tests for a sequence and select whether the interviewee should see the results at the end of their test.
+
+**Interview Storage Field** (optional): select a field to store all interview data for the associated record (interview data is typically stored in the external module log which is not accessible via the API), this field will be updated hourly with the latest data for _all_ interviews associated with the record.
+
 You may enable/disable the provider email feature here.
 You may also specify scheduled invitation and reminder email subject and body texts here. The module will replace`[interview-links]` and `[interview-urls]` with the actual patient-specific interview link/URLs at the time the emails are sent.
 
@@ -88,4 +91,4 @@ Version 2.2.0 adds a progress meter to the participant interview page.
 ![Interview progress meter](/docs/progress_meter.PNG)
 The number of circle icons indicates how many tests are included in the interview*. Blue circles denote a test being taken currently, green denotes completed tests, and gray denote tests that have yet to be started as part of the interview.
 
-*Note: Due to how the meter is implemented, the progress meter counts 'c/adhd' and 'a/adhd' to be a single test in the interview. This has to do with how the module detects which test a user is currently answering. The same is true for 'dep' and 'p-dep', 'anx' and 'p-anx', and 'm/hm' and 'p-m/hm' test sets. 
+*Note: Due to how the meter is implemented, the progress meter counts 'c/adhd' and 'a/adhd' to be a single test in the interview. This has to do with how the module detects which test a user is currently answering. The same is true for 'dep' and 'p-dep', 'anx' and 'p-anx', and 'm/hm' and 'p-m/hm' test sets.

--- a/config.json
+++ b/config.json
@@ -9,7 +9,12 @@
 
 	"authors": [
 		{
-			"name": "Carl Reed, Kyle McGuffin",
+			"name": "Kyle Chesney",
+			"email": "datacore@vumc.org",
+			"institution": "Vanderbilt University Medical Center"
+		},
+		{
+			"name": "Kyle McGuffin",
 			"email": "datacore@vumc.org",
 			"institution": "Vanderbilt University Medical Center"
 		}
@@ -70,6 +75,11 @@
 			"key": "disable_invites",
 			"name": "Disable automatic interview invitation and reminder emails",
 			"type": "checkbox"
+		},
+		{
+			"key": "interview_storage_field",
+			"name": "Interview Storage Field",
+			"type": "field-list"
 		},
 		{
 			"key": "enrollment_field",
@@ -272,6 +282,13 @@
 			"cron_name": "emailer_cron",
 			"cron_description": "Cron that runs every hour to send automatic interview invites and reminder emails",
 			"method": "emailer_cron",
+			"cron_frequency": "3600",
+			"cron_max_run_time": "3540"
+		},
+		{
+			"cron_name": "interview_to_field_cron",
+			"cron_description": "Cron that runs every hour to inject interview data into a field",
+			"method": "interview_to_field_cron",
 			"cron_frequency": "3600",
 			"cron_max_run_time": "3540"
 		}


### PR DESCRIPTION
Needed to allow API exfiltration of actual interview data Interview data is stored as JSON

# Pre-flight Checklist
- [x] Are all the features in this PR tested? 
~~- [ ] Have other features this PR touches also been tested?~~
- [x] Has the code been formatted for consistency and readability?
- [x] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
<!--Provide a summary  of this pr. Is this a new module? A new feature? a bug fix? a code reformat?-->
Adds a cron job that runs hourly to store interview data (as a JSON string) in a user-specified field in the project.

# Context
<!--Provide a URL to a Jira, Pivotal Tracker story, or Assembla ticket. If those are not appropriate, provide the requirements this PR addresses.-->
Client request to get interview data from API. Interview data is currently only stored in the module log and exposed on the "CAT-MH Interview Data Export" page.

# Screenshots
<!--Include screenshots of new pages or features to help other developers understand the features and markup.-->
