### PR TITLE
Add API endpoint to fetch interview data for all records

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,36 @@ Version 2.2.0 adds a progress meter to the participant interview page.
 The number of circle icons indicates how many tests are included in the interview*. Blue circles denote a test being taken currently, green denotes completed tests, and gray denote tests that have yet to be started as part of the interview.
 
 *Note: Due to how the meter is implemented, the progress meter counts 'c/adhd' and 'a/adhd' to be a single test in the interview. This has to do with how the module detects which test a user is currently answering. The same is true for 'dep' and 'p-dep', 'anx' and 'p-anx', and 'm/hm' and 'p-m/hm' test sets.
+
+## API
+
+Interview response data may be fetched via an [EM Framework API endpoint](https://github.com/vanderbilt-redcap/external-module-framework-docs/blob/main/api.md) with the action "get-interview-data". The interview data returned will be identical to what is provided on the "CAT-MH Interview Data Export" page with the record's primary key (e.g. `record_id`) included.
+
+Request query example:
+``` bash
+TOKEN="YOUR_PROJECT_API_TOKEN"
+API_ENDPOINT="https://your_institution.edu/redcap_vX.Y.Z/api/"
+
+curl -F "token=${TOKEN}" \
+     -F "content=externalModule" \
+     -F "prefix=cat_mh" \
+     -F "action=get-interview-data" \
+     -F "format=json" \
+     -F "returnFormat=json" \
+     "${API_ENDPOINT}"
+```
+
+Response example:
+``` json
+[
+  {
+    "<primary_key_field>": "<primary_key_value>",
+    "interview_data": [
+      { <interview_1_data> },
+      ... ,
+      { <interview_n_data> },
+    ],
+  },
+  ...
+]
+```

--- a/config.json
+++ b/config.json
@@ -300,6 +300,12 @@
 		"redcap-version-min": "",
 		"redcap-version-max": ""
 	},
-	
-	"framework-version": 5
+	"framework-version": 5,
+		"include-authors-in-api-info": true,
+		"api-actions": {
+				"get-interview-data": {
+						"description": "Gets all interview data for each record",
+						"access": ["auth"]
+				}
+		}
 }


### PR DESCRIPTION
Writing to field and performing core API export may result in truncated data as redcap_data<N>'s value column is TEXT (64 KB) while interview data is stored in the EM log in a column of type MEDIUMTEXT (16 MB)

# Pre-flight Checklist
- [x] Are all the features in this PR tested? 
~~- [ ] Have other features this PR touches also been tested?~~
- [x] Has the code been formatted for consistency and readability?
  - Ran PHPCSFixer on added lines
- [x] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
<!--Provide a summary  of this pr. Is this a new module? A new feature? a bug fix? a code reformat?-->

New feature, adds EMFW API endpoint to fetch CAT-MH interview data.

# Context
<!--Provide a URL to a Jira, Pivotal Tracker story, or Assembla ticket. If those are not appropriate, provide the requirements this PR addresses.-->

Client requested ability to pull interview data from API prior to addition of EM FW API. Initially addressed this issue by adding cron job to populate a user-specified REDCap field with interview data in PR #14; however, the client's interview data exceeded size of the `value` column for the `redcap_data` table (TEXT - 64 KB limit), resulting in truncated data being delivered (all interviews associated with a person injected into a single row).  
This PR adds an EM FW API endpoint that delivers data directly from the `redcap_external_modules_log_parameters` table where the module stores each individual interview's data (each interview is a row) in a MEDIUMTEXT column (16 MB limit).

The following bash snippet may prove useful for testing:  
``` bash
TOKEN="YOUR_PROJECT_API_TOKEN"
API_ENDPOINT="http://localhost/redcap_vX.Y.Z/api/"

curl -F "token=${TOKEN}" \
     -F "content=externalModule" \
     -F "prefix=cat_mh" \
     -F "action=get-interview-data" \
     -F "format=json" \
     -F "returnFormat=json" \
     "${API_ENDPOINT}"
```

I intentionally did not add a `redcap-version-min` to the `config.json` as only this (optional) feature is gated behind a minimum version, making this update harmless for outdated REDCap versions.  
I do wonder if the README should state a version minimum for this feature (or if my reasoning is altogether unsound).