### PR TITLE
Update timeout string detection

### DIFF
--- a/CAT_MH_CHA.php
+++ b/CAT_MH_CHA.php
@@ -1638,7 +1638,7 @@ class CAT_MH_CHA extends \ExternalModules\AbstractExternalModule {
 		// handle response
 		try {
 			$json = json_decode($curl['body'], true);
-			if (strpos($curl['body'], "CAT-MH&trade; Timeout Error") === false) {
+			if (strpos($curl['body'], "Timeout Error") === false) {
 				if (gettype($json) != 'array') throw new \Exception("json error");
 			} else {
 				// timed out, need to send another auth request


### PR DESCRIPTION
"CAT-MH&trade;" has changed to "CAT-MH&reg;"
Simply remove the tag, detect only the timeout string

# Pre-flight Checklist
- [x] Are all the features in this PR tested? 
- [x] Have other features this PR touches also been tested?
- [x] Has the code been formatted for consistency and readability?
- [x] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
<!--Provide a summary  of this pr. Is this a new module? A new feature? a bug fix? a code reformat?-->

CAT-MH API has changed the HTML (`$trade` ™ changed to `$reg;` ®) returned on a timeout error resulting in respondents not being able to continue a survey. Simply removing the check for the IP symbol of choice seemed like the simplest solution.

# Context
<!--Provide a URL to a Jira, Pivotal Tracker story, or Assembla ticket. If those are not appropriate, provide the requirements this PR addresses.-->

# Screenshots
<!--Include screenshots of new pages or features to help other developers understand the features and markup.-->
